### PR TITLE
Resolves issue #3, License Mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "cve-core",
       "version": "2.1.0-rc2",
-      "license": "Apache-2.0",
+      "license": "(CC0)",
       "dependencies": {
         "@commander-js/extra-typings": "^10.0.2",
         "@opensearch-project/opensearch": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "prep:publish": "npm pack --dry-run",
     "coverage": "jest --coverage"
   },
-  "license": "Apache-2.0",
+  "license": "(CC0)",
   "dependencies": {
     "@commander-js/extra-typings": "^10.0.2",
     "@opensearch-project/opensearch": "^2.3.1",


### PR DESCRIPTION
Closes Issue #3 

# Summary
Fixing the license references in the package files on dev, which previously specified a different license than the one we actually include.

# Important Changes
`package.json`
- Changed reference from Apache to CC0

`package-lock.json`
- Changed reference from Apache to CC0

# Testing

N/A
